### PR TITLE
Add OS pid to pipeline name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image:  membrane/membrane:latest
         environment:
           MIX_ENV: test
-      - image: timescale/timescaledb:latest-pg11
+      - image: timescale/timescaledb:1.7.4-pg12
         command: [-cshared_preload_libraries=timescaledb]
         environment:
           POSTGRES_USER: postgres

--- a/lib/timescaledb/reporter.ex
+++ b/lib/timescaledb/reporter.ex
@@ -33,15 +33,15 @@ defmodule Membrane.Telemetry.TimescaleDB.Reporter do
 
   def send_measurement(
         [:membrane, :input_buffer, :size] = event_name,
-        %{element_path: path, method: method, value: value}
+        %{element_path: path, method: method, value: value} = measurement
       )
       when is_binary(path) and is_binary(method) and is_integer(value) do
-    measurement = %{
-      element_path: extend_with_os_pid(path),
-      method: method,
-      value: value,
-      time: NaiveDateTime.utc_now()
-    }
+    measurement =
+      measurement
+      |> Map.merge(%{
+        element_path: extend_with_os_pid(path),
+        time: NaiveDateTime.utc_now()
+      })
 
     GenServer.cast(
       __MODULE__,
@@ -51,18 +51,16 @@ defmodule Membrane.Telemetry.TimescaleDB.Reporter do
 
   def send_measurement(
         [:membrane, :link, :new],
-        %{parent_path: parent_path, from: from, to: to, pad_from: pad_from, pad_to: pad_to}
+        %{parent_path: parent_path, from: from, to: to, pad_from: pad_from, pad_to: pad_to} = link
       )
       when is_binary(parent_path) and is_binary(from) and is_binary(to) and is_binary(pad_from) and
              is_binary(pad_to) do
-    link = %{
-      parent_path: extend_with_os_pid(parent_path),
-      from: from,
-      to: to,
-      pad_from: pad_from,
-      pad_to: pad_to,
-      time: NaiveDateTime.utc_now()
-    }
+    link =
+      link
+      |> Map.merge(%{
+        parent_path: extend_with_os_pid(parent_path),
+        time: NaiveDateTime.utc_now()
+      })
 
     GenServer.cast(
       __MODULE__,


### PR DESCRIPTION
Adding OS pid to pipeline name solves problem with uniqueness when running applications in parallel on the same device. Resolves issues:
- [Investigate handling more than one pipeline #4](https://github.com/membraneframework/membrane_dashboard/issues/4)
- [Unique violation error when running the same pipeline twice in parallel #5](https://github.com/membraneframework/membrane_timescaledb_reporter/issues/5)
