### PR TITLE
Fix migrations to eliminate crashing while migrating and running.

### DIFF
--- a/priv/repo/migrations/20200723112205_create_extension_timescaledb.exs
+++ b/priv/repo/migrations/20200723112205_create_extension_timescaledb.exs
@@ -7,8 +7,8 @@ defmodule Membrane.Telemetry.TimescaleDB.Repo.Migrations.CreateExtensionTimescal
   @chunk_compress_policy_interval Application.get_env(:membrane_timescaledb_reporter,Repo)[:chunk_compress_policy_interval] || "10 minutes"
 
   def up() do
-    create table(:component_paths, primary_key: {:id, :id, autogenerate: true}) do
-      add(:path, :string, null: false)
+    create table(:component_paths) do
+      add(:path, :text, null: false)
     end
 
     create unique_index(:component_paths, :path)

--- a/priv/repo/migrations/20200804074333_add_links_table.exs
+++ b/priv/repo/migrations/20200804074333_add_links_table.exs
@@ -4,7 +4,7 @@ defmodule Membrane.Telemetry.TimescaleDB.Repo.Migrations.AddLinksTable do
   def change do
     create table(:links, primary_key: false) do
       add(:time, :naive_datetime_usec, null: false)
-      add(:parent_path, :string, null: false)
+      add(:parent_path, :text, null: false)
       add(:from, :string, null: false)
       add(:to, :string, null: false)
       add(:pad_from, :string, null: false)

--- a/priv/repo/migrations/20210707095922_add_element_table.exs
+++ b/priv/repo/migrations/20210707095922_add_element_table.exs
@@ -4,7 +4,7 @@ defmodule Membrane.Telemetry.TimescaleDB.Repo.Migrations.AddElementTable do
   def change do
     create table(:elements, primary_key: false) do
       add(:time, :naive_datetime_usec, null: false)
-      add(:path, :string, null: false)
+      add(:path, :text, null: false)
       add(:terminated, :bool, null: false)
     end
 


### PR DESCRIPTION
Some of the crashes were caused by the migrations just passing misformatted values as parameters to Ecto functions.

Others were caused by paths inside big pipelines were too long to fit in a 255 chars long `varchar`.